### PR TITLE
Allow null for localWorkSize

### DIFF
--- a/NOpenCL/UnsafeNativeMethods.KernelExecution.cs
+++ b/NOpenCL/UnsafeNativeMethods.KernelExecution.cs
@@ -38,8 +38,6 @@ namespace NOpenCL
                 throw new ArgumentNullException("kernel");
             if (globalWorkSize == null)
                 throw new ArgumentNullException("globalWorkSize");
-            if (localWorkSize == null)
-                throw new ArgumentNullException("localWorkSize");
 
             uint workDim = (uint)globalWorkSize.Length;
             if (globalWorkOffset != null && globalWorkOffset.Length != workDim)


### PR DESCRIPTION
The `EnqueueNDRangeKernel` method threw if `localWorkSize` was null, which is allowed according to the spec.  I just removed the null check so it works the same as `globalWorkOffset` (it looks like the null check was added in error judging by the `if` statement farther down).