### PR TITLE
Treat warnings as errors for command line builds

### DIFF
--- a/NOpenCL.Test/NOpenCL.Test.csproj
+++ b/NOpenCL.Test/NOpenCL.Test.csproj
@@ -36,6 +36,10 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <!-- Ideally this is always enabled, but that tends to hurt developer productivity -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
   <PropertyGroup>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\TunnelVisionLabs.NOpenCL.UnitTest.ruleset</CodeAnalysisRuleSet>

--- a/NOpenCL/NOpenCL.csproj
+++ b/NOpenCL/NOpenCL.csproj
@@ -33,6 +33,10 @@
     <NoWarn>1591</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <!-- Ideally this is always enabled, but that tends to hurt developer productivity -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
   <PropertyGroup>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <CodeAnalysisRuleSet>..\TunnelVisionLabs.NOpenCL.ruleset</CodeAnalysisRuleSet>

--- a/TunnelVisionLabs.NOpenCL.ruleset
+++ b/TunnelVisionLabs.NOpenCL.ruleset
@@ -3,13 +3,6 @@
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0003" Action="None" />
   </Rules>
-  <Rules AnalyzerId="PublicApiAnalyzer" RuleNamespace="PublicApiAnalyzer">
-    <Rule Id="RS0016" Action="Error" />
-    <Rule Id="RS0017" Action="Error" />
-    <Rule Id="RS0022" Action="Error" />
-    <Rule Id="RS0024" Action="Error" />
-    <Rule Id="RS0025" Action="Error" />
-  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1102" Action="None" />


### PR DESCRIPTION
This includes AppVeyor, but not cases where developers are trying to iterate quickly within the IDE.