### PR TITLE
Rewrite NOpenCL.Buffer as generic type Buffer<T>

### DIFF
--- a/NOpenCL.Test/Intel/Optimization.cs
+++ b/NOpenCL.Test/Intel/Optimization.cs
@@ -6,7 +6,6 @@ namespace NOpenCL.Test.Intel
     using System;
     using System.Diagnostics;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Buffer = NOpenCL.Buffer;
 
     [TestClass]
     public class Optimization
@@ -113,8 +112,8 @@ namespace NOpenCL.Test.Intel
             // allocate buffers
             fixed (float* pinput = input, poutput = output)
             {
-                using (Buffer inputBuffer = context.CreateBuffer(inFlags, sizeof(float) * taskSize, (IntPtr)pinput),
-                    outputBuffer = context.CreateBuffer(outFlags, sizeof(float) * taskSize, (IntPtr)poutput))
+                using (Buffer<float> inputBuffer = context.CreateBuffer<float>(inFlags, sizeof(float) * taskSize, (IntPtr)pinput),
+                    outputBuffer = context.CreateBuffer<float>(outFlags, sizeof(float) * taskSize, (IntPtr)poutput))
                 {
                     kernel.Arguments[0].SetValue(inputBuffer);
                     kernel.Arguments[1].SetValue(outputBuffer);

--- a/NOpenCL.Test/NVidia/Bandwidth.cs
+++ b/NOpenCL.Test/NVidia/Bandwidth.cs
@@ -7,7 +7,6 @@ namespace NOpenCL.Test.NVidia
     using System.Diagnostics;
     using System.Runtime.InteropServices;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Buffer = NOpenCL.Buffer;
 
     [TestClass]
     public class Bandwidth
@@ -171,7 +170,7 @@ namespace NOpenCL.Test.NVidia
         private double TestDeviceToHostTransferPinned(Context context, CommandQueue commandQueue, int memSize, AccessMode accessMode)
         {
             // create a host buffer
-            using (Buffer pinnedData = context.CreateBuffer(MemoryFlags.ReadWrite | MemoryFlags.AllocateHostPointer, memSize))
+            using (Buffer<byte> pinnedData = context.CreateBuffer<byte>(MemoryFlags.ReadWrite | MemoryFlags.AllocateHostPointer, memSize))
             {
                 // get a mapped pointer
                 IntPtr h_data;
@@ -185,7 +184,7 @@ namespace NOpenCL.Test.NVidia
                 commandQueue.EnqueueUnmapMemObject(pinnedData, h_data);
 
                 // allocate device memory
-                using (Buffer deviceData = context.CreateBuffer(MemoryFlags.ReadWrite, memSize))
+                using (Buffer<byte> deviceData = context.CreateBuffer<byte>(MemoryFlags.ReadWrite, memSize))
                 {
                     // initialize device memory
                     commandQueue.EnqueueMapBuffer(pinnedData, true, MapFlags.Write, 0, memSize, out h_data);
@@ -244,7 +243,7 @@ namespace NOpenCL.Test.NVidia
             fixed (byte* pdata = data)
             {
                 // allocate device memory
-                using (Buffer deviceData = context.CreateBuffer(MemoryFlags.ReadWrite, memSize))
+                using (Buffer<byte> deviceData = context.CreateBuffer<byte>(MemoryFlags.ReadWrite, memSize))
                 {
                     // initialize device memory
                     commandQueue.EnqueueWriteBuffer(deviceData, false, 0, memSize, (IntPtr)pdata);
@@ -299,7 +298,7 @@ namespace NOpenCL.Test.NVidia
         private double TestHostToDeviceTransferPinned(Context context, CommandQueue commandQueue, int memSize, AccessMode accessMode)
         {
             // Create a host buffer
-            using (Buffer pinnedData = context.CreateBuffer(MemoryFlags.ReadWrite | MemoryFlags.AllocateHostPointer, memSize))
+            using (Buffer<byte> pinnedData = context.CreateBuffer<byte>(MemoryFlags.ReadWrite | MemoryFlags.AllocateHostPointer, memSize))
             {
                 // get a mapped pointer
                 IntPtr h_data;
@@ -313,7 +312,7 @@ namespace NOpenCL.Test.NVidia
                 commandQueue.EnqueueUnmapMemObject(pinnedData, h_data);
 
                 // allocate device memory
-                using (Buffer deviceData = context.CreateBuffer(MemoryFlags.ReadWrite, memSize))
+                using (Buffer<byte> deviceData = context.CreateBuffer<byte>(MemoryFlags.ReadWrite, memSize))
                 {
                     // sync queue to host
                     commandQueue.Finish();
@@ -368,7 +367,7 @@ namespace NOpenCL.Test.NVidia
             fixed (byte* pdata = data)
             {
                 // allocate device memory
-                using (Buffer deviceData = context.CreateBuffer(MemoryFlags.ReadWrite, memSize))
+                using (Buffer<byte> deviceData = context.CreateBuffer<byte>(MemoryFlags.ReadWrite, memSize))
                 {
                     // sync queue to host
                     commandQueue.Finish();
@@ -425,8 +424,8 @@ namespace NOpenCL.Test.NVidia
                 data[i] = 0xFF;
 
             // allocate device input and output memory and initialize the device input memory
-            using (Buffer d_idata = context.CreateBuffer(MemoryFlags.ReadOnly, memorySize),
-                d_odata = context.CreateBuffer(MemoryFlags.WriteOnly, memorySize))
+            using (Buffer<byte> d_idata = context.CreateBuffer<byte>(MemoryFlags.ReadOnly, memorySize),
+                d_odata = context.CreateBuffer<byte>(MemoryFlags.WriteOnly, memorySize))
             {
                 unsafe
                 {

--- a/NOpenCL.Test/NVidia/VectorAdd.cs
+++ b/NOpenCL.Test/NVidia/VectorAdd.cs
@@ -5,7 +5,6 @@ namespace NOpenCL.Test.NVidia
 {
     using System;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Buffer = NOpenCL.Buffer;
 
     [TestClass]
     public class VectorAdd
@@ -64,9 +63,9 @@ namespace NOpenCL.Test.NVidia
                 using (CommandQueue commandQueue = context.CreateCommandQueue(devices[0], CommandQueueProperties.None))
                 {
                     Console.WriteLine("Create buffers...");
-                    using (Buffer deviceSrcA = context.CreateBuffer(MemoryFlags.ReadOnly, globalWorkSize * sizeof(float)),
-                        deviceSrcB = context.CreateBuffer(MemoryFlags.ReadOnly, globalWorkSize * sizeof(float)),
-                        deviceDst = context.CreateBuffer(MemoryFlags.WriteOnly, globalWorkSize * sizeof(float)))
+                    using (Buffer<float> deviceSrcA = context.CreateBuffer<float>(MemoryFlags.ReadOnly, globalWorkSize * sizeof(float)),
+                        deviceSrcB = context.CreateBuffer<float>(MemoryFlags.ReadOnly, globalWorkSize * sizeof(float)),
+                        deviceDst = context.CreateBuffer<float>(MemoryFlags.WriteOnly, globalWorkSize * sizeof(float)))
                     {
                         string source =
                             @"// OpenCL Kernel Function for element by element vector addition

--- a/NOpenCL.Test/TestBuffers.cs
+++ b/NOpenCL.Test/TestBuffers.cs
@@ -4,7 +4,6 @@
 namespace NOpenCL.Test
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Buffer = NOpenCL.Buffer;
 
     [TestClass]
     public class TestBuffers
@@ -17,7 +16,7 @@ namespace NOpenCL.Test
             Platform platform = Platform.GetPlatforms()[0];
             using (Context context = Context.Create(platform.GetDevices()))
             {
-                using (Buffer buffer = context.CreateBuffer(MemoryFlags.AllocateHostPointer, 1024))
+                using (Buffer<byte> buffer = context.CreateBuffer<byte>(MemoryFlags.AllocateHostPointer, 1024))
                 {
                     buffer.Destroyed += (sender, e) => destroyed = true;
                     Assert.IsFalse(destroyed);

--- a/NOpenCL/BufferCreateType.cs
+++ b/NOpenCL/BufferCreateType.cs
@@ -4,7 +4,7 @@
 namespace NOpenCL
 {
     /// <summary>
-    /// Describes the type of buffer object to be created by <see cref="Buffer.CreateSubBuffer"/>.
+    /// Describes the type of buffer object to be created by <see cref="Buffer{T}.CreateSubBuffer"/>.
     /// </summary>
     public enum BufferCreateType
     {

--- a/NOpenCL/Buffer`1.cs
+++ b/NOpenCL/Buffer`1.cs
@@ -6,16 +6,17 @@ namespace NOpenCL
     using System;
     using NOpenCL.SafeHandles;
 
-    public sealed class Buffer : MemObject<BufferSafeHandle>
+    public sealed class Buffer<T> : MemObject<BufferSafeHandle>
+        where T : struct
     {
-        private readonly Buffer _parent;
+        private readonly Buffer<T> _parent;
 
         internal Buffer(Context context, BufferSafeHandle handle)
             : base(context, handle)
         {
         }
 
-        internal Buffer(Context context, Buffer parent, BufferSafeHandle handle)
+        internal Buffer(Context context, Buffer<T> parent, BufferSafeHandle handle)
             : base(context, handle)
         {
             if (parent == null)
@@ -24,7 +25,7 @@ namespace NOpenCL
             _parent = parent;
         }
 
-        public Buffer AssociatedMemObject
+        public Buffer<T> AssociatedMemObject
         {
             get
             {
@@ -41,10 +42,10 @@ namespace NOpenCL
             }
         }
 
-        public Buffer CreateSubBuffer(MemoryFlags flags, BufferRegion regionInfo)
+        public Buffer<T> CreateSubBuffer(MemoryFlags flags, BufferRegion regionInfo)
         {
             BufferSafeHandle subBuffer = UnsafeNativeMethods.CreateSubBuffer(Handle, flags, regionInfo);
-            return new Buffer(Context, this, subBuffer);
+            return new Buffer<T>(Context, this, subBuffer);
         }
     }
 }

--- a/NOpenCL/CommandQueue.cs
+++ b/NOpenCL/CommandQueue.cs
@@ -97,7 +97,8 @@ namespace NOpenCL
             }
         }
 
-        public Event EnqueueReadBuffer(Buffer buffer, bool blocking, long offset, long size, IntPtr destination, params Event[] eventWaitList)
+        public Event EnqueueReadBuffer<T>(Buffer<T> buffer, bool blocking, long offset, long size, IntPtr destination, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -107,7 +108,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueReadBufferRect(Buffer buffer, bool blocking, BufferCoordinates bufferOrigin, BufferCoordinates hostOrigin, BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, IntPtr destination, params Event[] eventWaitList)
+        public Event EnqueueReadBufferRect<T>(Buffer<T> buffer, bool blocking, BufferCoordinates bufferOrigin, BufferCoordinates hostOrigin, BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, IntPtr destination, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -117,7 +119,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueWriteBuffer(Buffer buffer, bool blocking, long offset, long size, IntPtr source, params Event[] eventWaitList)
+        public Event EnqueueWriteBuffer<T>(Buffer<T> buffer, bool blocking, long offset, long size, IntPtr source, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -127,7 +130,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueWriteBufferRect(Buffer buffer, bool blocking, BufferCoordinates bufferOrigin, BufferCoordinates hostOrigin, BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, IntPtr source, params Event[] eventWaitList)
+        public Event EnqueueWriteBufferRect<T>(Buffer<T> buffer, bool blocking, BufferCoordinates bufferOrigin, BufferCoordinates hostOrigin, BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, IntPtr source, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -137,7 +141,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueCopyBuffer(Buffer source, Buffer destination, long sourceOffset, long destinationOffset, long size, params Event[] eventWaitList)
+        public Event EnqueueCopyBuffer<T>(Buffer<T> source, Buffer<T> destination, long sourceOffset, long destinationOffset, long size, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -147,7 +152,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueCopyBufferRect(Buffer source, Buffer destination, BufferCoordinates sourceOrigin, BufferCoordinates destinationOrigin, BufferSize region, long sourceRowPitch, long sourceSlicePitch, long destinationRowPitch, long destinationSlicePitch, params Event[] eventWaitList)
+        public Event EnqueueCopyBufferRect<T>(Buffer<T> source, Buffer<T> destination, BufferCoordinates sourceOrigin, BufferCoordinates destinationOrigin, BufferSize region, long sourceRowPitch, long sourceSlicePitch, long destinationRowPitch, long destinationSlicePitch, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -157,7 +163,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueMapBuffer(Buffer buffer, bool blocking, MapFlags mapFlags, long offset, long size, out IntPtr mappedPointer, params Event[] eventWaitList)
+        public Event EnqueueMapBuffer<T>(Buffer<T> buffer, bool blocking, MapFlags mapFlags, long offset, long size, out IntPtr mappedPointer, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -227,7 +234,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueCopyImageToBuffer(Image sourceImage, Buffer destinationBuffer, BufferCoordinates sourceOrigin, BufferSize region, long destinationOffset, params Event[] eventWaitList)
+        public Event EnqueueCopyImageToBuffer<T>(Image sourceImage, Buffer<T> destinationBuffer, BufferCoordinates sourceOrigin, BufferSize region, long destinationOffset, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)
@@ -237,7 +245,8 @@ namespace NOpenCL
             return new Event(handle);
         }
 
-        public Event EnqueueCopyBufferToImage(Buffer sourceBuffer, Image destinationImage, long sourceOffset, BufferCoordinates destinationOrigin, BufferSize region, params Event[] eventWaitList)
+        public Event EnqueueCopyBufferToImage<T>(Buffer<T> sourceBuffer, Image destinationImage, long sourceOffset, BufferCoordinates destinationOrigin, BufferSize region, params Event[] eventWaitList)
+            where T : struct
         {
             EventSafeHandle[] eventHandles = null;
             if (eventWaitList != null)

--- a/NOpenCL/Context.cs
+++ b/NOpenCL/Context.cs
@@ -110,12 +110,14 @@ namespace NOpenCL
             return new CommandQueue(handle, this, device);
         }
 
-        public Buffer CreateBuffer(MemoryFlags flags, long size)
+        public Buffer<T> CreateBuffer<T>(MemoryFlags flags, long size)
+            where T : struct
         {
-            return CreateBuffer(flags, size, IntPtr.Zero);
+            return CreateBuffer<T>(flags, size, IntPtr.Zero);
         }
 
-        public Buffer CreateBuffer(MemoryFlags flags, long size, IntPtr hostAddress)
+        public Buffer<T> CreateBuffer<T>(MemoryFlags flags, long size, IntPtr hostAddress)
+            where T : struct
         {
             if (size < 0)
                 throw new ArgumentOutOfRangeException(nameof(size));
@@ -128,7 +130,7 @@ namespace NOpenCL
                 throw new ArgumentException("Invalid host address.", nameof(hostAddress));
 
             BufferSafeHandle handle = UnsafeNativeMethods.CreateBuffer(Handle, flags, (IntPtr)size, hostAddress);
-            return new Buffer(this, handle);
+            return new Buffer<T>(this, handle);
         }
 
         public Image CreateImage(MemoryFlags flags, ImageFormat format, ImageDescriptor descriptor)

--- a/NOpenCL/Image.cs
+++ b/NOpenCL/Image.cs
@@ -77,7 +77,7 @@ namespace NOpenCL
             }
         }
 
-        public Buffer Buffer
+        public Buffer<byte> Buffer
         {
             get
             {

--- a/NOpenCL/KernelArgument.cs
+++ b/NOpenCL/KernelArgument.cs
@@ -77,7 +77,8 @@ namespace NOpenCL
             }
         }
 
-        public void SetValue(Buffer buffer)
+        public void SetValue<T>(Buffer<T> buffer)
+            where T : struct
         {
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));

--- a/NOpenCL/MemObjectType.cs
+++ b/NOpenCL/MemObjectType.cs
@@ -11,7 +11,7 @@ namespace NOpenCL
         /// <summary>
         /// A buffer.
         /// </summary>
-        /// <seealso cref="NOpenCL.Buffer"/>
+        /// <seealso cref="NOpenCL.Buffer{T}"/>
         Buffer = 0x10F0,
 
         /// <summary>

--- a/NOpenCL/NOpenCL.csproj
+++ b/NOpenCL/NOpenCL.csproj
@@ -56,7 +56,7 @@
     <Compile Include="AddressQualifier.cs" />
     <Compile Include="AffinityDomain.cs" />
     <Compile Include="BinaryType.cs" />
-    <Compile Include="Buffer.cs" />
+    <Compile Include="Buffer`1.cs" />
     <Compile Include="BufferCoordinates.cs" />
     <Compile Include="BufferCreateType.cs" />
     <Compile Include="BufferRegion.cs" />

--- a/NOpenCL/PublicAPI.Unshipped.txt
+++ b/NOpenCL/PublicAPI.Unshipped.txt
@@ -27,10 +27,10 @@ NOpenCL.BinaryType.CompiledObject = 1 -> NOpenCL.BinaryType
 NOpenCL.BinaryType.Executable = 4 -> NOpenCL.BinaryType
 NOpenCL.BinaryType.Library = 2 -> NOpenCL.BinaryType
 NOpenCL.BinaryType.None = 0 -> NOpenCL.BinaryType
-NOpenCL.Buffer
-NOpenCL.Buffer.AssociatedMemObject.get -> NOpenCL.Buffer
-NOpenCL.Buffer.CreateSubBuffer(NOpenCL.MemoryFlags flags, NOpenCL.BufferRegion regionInfo) -> NOpenCL.Buffer
-NOpenCL.Buffer.Offset.get -> System.UIntPtr
+NOpenCL.Buffer<T>
+NOpenCL.Buffer<T>.AssociatedMemObject.get -> NOpenCL.Buffer<T>
+NOpenCL.Buffer<T>.CreateSubBuffer(NOpenCL.MemoryFlags flags, NOpenCL.BufferRegion regionInfo) -> NOpenCL.Buffer<T>
+NOpenCL.Buffer<T>.Offset.get -> System.UIntPtr
 NOpenCL.BufferCoordinates
 NOpenCL.BufferCoordinates.BufferCoordinates(System.IntPtr x, System.IntPtr y) -> void
 NOpenCL.BufferCoordinates.BufferCoordinates(System.IntPtr x, System.IntPtr y, System.IntPtr z) -> void
@@ -88,15 +88,15 @@ NOpenCL.CommandQueue.Context.get -> NOpenCL.Context
 NOpenCL.CommandQueue.Device.get -> NOpenCL.Device
 NOpenCL.CommandQueue.Dispose() -> void
 NOpenCL.CommandQueue.EnqueueBarrier(params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueCopyBuffer(NOpenCL.Buffer source, NOpenCL.Buffer destination, long sourceOffset, long destinationOffset, long size, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueCopyBufferRect(NOpenCL.Buffer source, NOpenCL.Buffer destination, NOpenCL.BufferCoordinates sourceOrigin, NOpenCL.BufferCoordinates destinationOrigin, NOpenCL.BufferSize region, long sourceRowPitch, long sourceSlicePitch, long destinationRowPitch, long destinationSlicePitch, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueCopyBufferToImage(NOpenCL.Buffer sourceBuffer, NOpenCL.Image destinationImage, long sourceOffset, NOpenCL.BufferCoordinates destinationOrigin, NOpenCL.BufferSize region, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueCopyBuffer<T>(NOpenCL.Buffer<T> source, NOpenCL.Buffer<T> destination, long sourceOffset, long destinationOffset, long size, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueCopyBufferRect<T>(NOpenCL.Buffer<T> source, NOpenCL.Buffer<T> destination, NOpenCL.BufferCoordinates sourceOrigin, NOpenCL.BufferCoordinates destinationOrigin, NOpenCL.BufferSize region, long sourceRowPitch, long sourceSlicePitch, long destinationRowPitch, long destinationSlicePitch, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueCopyBufferToImage<T>(NOpenCL.Buffer<T> sourceBuffer, NOpenCL.Image destinationImage, long sourceOffset, NOpenCL.BufferCoordinates destinationOrigin, NOpenCL.BufferSize region, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueCopyImage(NOpenCL.Image sourceImage, NOpenCL.Image destinationImage, NOpenCL.BufferCoordinates sourceOrigin, NOpenCL.BufferCoordinates destinationOrigin, NOpenCL.BufferSize region, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueCopyImageToBuffer(NOpenCL.Image sourceImage, NOpenCL.Buffer destinationBuffer, NOpenCL.BufferCoordinates sourceOrigin, NOpenCL.BufferSize region, long destinationOffset, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueCopyImageToBuffer<T>(NOpenCL.Image sourceImage, NOpenCL.Buffer<T> destinationBuffer, NOpenCL.BufferCoordinates sourceOrigin, NOpenCL.BufferSize region, long destinationOffset, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueFillImage(NOpenCL.Image image, float[] fillColor, NOpenCL.BufferCoordinates origin, NOpenCL.BufferSize region, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueFillImage(NOpenCL.Image image, int[] fillColor, NOpenCL.BufferCoordinates origin, NOpenCL.BufferSize region, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueFillImage(NOpenCL.Image image, uint[] fillColor, NOpenCL.BufferCoordinates origin, NOpenCL.BufferSize region, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueMapBuffer(NOpenCL.Buffer buffer, bool blocking, NOpenCL.MapFlags mapFlags, long offset, long size, out System.IntPtr mappedPointer, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueMapBuffer<T>(NOpenCL.Buffer<T> buffer, bool blocking, NOpenCL.MapFlags mapFlags, long offset, long size, out System.IntPtr mappedPointer, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueMapImage(NOpenCL.Image image, bool blocking, NOpenCL.MapFlags mapFlags, NOpenCL.BufferCoordinates origin, NOpenCL.BufferSize region, out long rowPitch, out long slicePitch, out System.IntPtr mappedPointer, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueMarker(params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueMigrateMemObjects(NOpenCL.MemObject[] memObjects, NOpenCL.MigrationFlags flags, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
@@ -104,13 +104,13 @@ NOpenCL.CommandQueue.EnqueueNDRangeKernel(NOpenCL.Kernel kernel, System.IntPtr g
 NOpenCL.CommandQueue.EnqueueNDRangeKernel(NOpenCL.Kernel kernel, System.IntPtr globalWorkSize, System.IntPtr localWorkSize, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueNDRangeKernel(NOpenCL.Kernel kernel, System.IntPtr[] globalWorkOffset, System.IntPtr[] globalWorkSize, System.IntPtr[] localWorkSize, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueNDRangeKernel(NOpenCL.Kernel kernel, System.IntPtr[] globalWorkSize, System.IntPtr[] localWorkSize, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueReadBuffer(NOpenCL.Buffer buffer, bool blocking, long offset, long size, System.IntPtr destination, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueReadBufferRect(NOpenCL.Buffer buffer, bool blocking, NOpenCL.BufferCoordinates bufferOrigin, NOpenCL.BufferCoordinates hostOrigin, NOpenCL.BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, System.IntPtr destination, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueReadBuffer<T>(NOpenCL.Buffer<T> buffer, bool blocking, long offset, long size, System.IntPtr destination, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueReadBufferRect<T>(NOpenCL.Buffer<T> buffer, bool blocking, NOpenCL.BufferCoordinates bufferOrigin, NOpenCL.BufferCoordinates hostOrigin, NOpenCL.BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, System.IntPtr destination, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueReadImage(NOpenCL.Image image, bool blocking, NOpenCL.BufferCoordinates origin, NOpenCL.BufferSize region, long rowPitch, long slicePitch, System.IntPtr destination, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueTask(NOpenCL.Kernel kernel, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueUnmapMemObject(NOpenCL.MemObject memObject, System.IntPtr mappedPointer, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueWriteBuffer(NOpenCL.Buffer buffer, bool blocking, long offset, long size, System.IntPtr source, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
-NOpenCL.CommandQueue.EnqueueWriteBufferRect(NOpenCL.Buffer buffer, bool blocking, NOpenCL.BufferCoordinates bufferOrigin, NOpenCL.BufferCoordinates hostOrigin, NOpenCL.BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, System.IntPtr source, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueWriteBuffer<T>(NOpenCL.Buffer<T> buffer, bool blocking, long offset, long size, System.IntPtr source, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
+NOpenCL.CommandQueue.EnqueueWriteBufferRect<T>(NOpenCL.Buffer<T> buffer, bool blocking, NOpenCL.BufferCoordinates bufferOrigin, NOpenCL.BufferCoordinates hostOrigin, NOpenCL.BufferSize region, long bufferRowPitch, long bufferSlicePitch, long hostRowPitch, long hostSlicePitch, System.IntPtr source, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.EnqueueWriteImage(NOpenCL.Image image, bool blocking, NOpenCL.BufferCoordinates origin, NOpenCL.BufferSize region, long inputRowPitch, long inputSlicePitch, System.IntPtr source, params NOpenCL.Event[] eventWaitList) -> NOpenCL.Event
 NOpenCL.CommandQueue.Finish() -> void
 NOpenCL.CommandQueue.Flush() -> void
@@ -154,8 +154,8 @@ NOpenCL.CommandType.WriteBuffer = 4596 -> NOpenCL.CommandType
 NOpenCL.CommandType.WriteBufferRect = 4610 -> NOpenCL.CommandType
 NOpenCL.CommandType.WriteImage = 4599 -> NOpenCL.CommandType
 NOpenCL.Context
-NOpenCL.Context.CreateBuffer(NOpenCL.MemoryFlags flags, long size) -> NOpenCL.Buffer
-NOpenCL.Context.CreateBuffer(NOpenCL.MemoryFlags flags, long size, System.IntPtr hostAddress) -> NOpenCL.Buffer
+NOpenCL.Context.CreateBuffer<T>(NOpenCL.MemoryFlags flags, long size) -> NOpenCL.Buffer<T>
+NOpenCL.Context.CreateBuffer<T>(NOpenCL.MemoryFlags flags, long size, System.IntPtr hostAddress) -> NOpenCL.Buffer<T>
 NOpenCL.Context.CreateCommandQueue(NOpenCL.Device device) -> NOpenCL.CommandQueue
 NOpenCL.Context.CreateCommandQueue(NOpenCL.Device device, NOpenCL.CommandQueueProperties properties) -> NOpenCL.CommandQueue
 NOpenCL.Context.CreateImage(NOpenCL.MemoryFlags flags, NOpenCL.ImageFormat format, NOpenCL.ImageDescriptor descriptor) -> NOpenCL.Image
@@ -302,7 +302,7 @@ NOpenCL.FloatingPointConfiguration.RoundToZero = 8 -> NOpenCL.FloatingPointConfi
 NOpenCL.FloatingPointConfiguration.SoftFloat = 64 -> NOpenCL.FloatingPointConfiguration
 NOpenCL.Image
 NOpenCL.Image.ArraySize.get -> System.UIntPtr
-NOpenCL.Image.Buffer.get -> NOpenCL.Buffer
+NOpenCL.Image.Buffer.get -> NOpenCL.Buffer<byte>
 NOpenCL.Image.Depth.get -> System.UIntPtr
 NOpenCL.Image.ElementSize.get -> System.UIntPtr
 NOpenCL.Image.Format.get -> NOpenCL.ImageFormat
@@ -335,10 +335,10 @@ NOpenCL.KernelArgument.AddressQualifier.get -> NOpenCL.AddressQualifier
 NOpenCL.KernelArgument.Index.get -> int
 NOpenCL.KernelArgument.Kernel.get -> NOpenCL.Kernel
 NOpenCL.KernelArgument.Name.get -> string
-NOpenCL.KernelArgument.SetValue(NOpenCL.Buffer buffer) -> void
 NOpenCL.KernelArgument.SetValue(NOpenCL.Image image) -> void
 NOpenCL.KernelArgument.SetValue(System.UIntPtr size, System.IntPtr value) -> void
 NOpenCL.KernelArgument.SetValue(int value) -> void
+NOpenCL.KernelArgument.SetValue<T>(NOpenCL.Buffer<T> buffer) -> void
 NOpenCL.KernelArgument.TypeName.get -> string
 NOpenCL.KernelArgument.TypeQualifiers.get -> NOpenCL.TypeQualifiers
 NOpenCL.LocalMemoryType


### PR DESCRIPTION
Rename `NOpenCL.Buffer` to generic type `Buffer<T>`.

Indirectly resolves the naming collision with `System.Buffer` identified by @SunsetQuest in https://github.com/tunnelvisionlabs/NOpenCL/pull/1/commits/74bc9baf40cace8e1a9d7fbdcd05527ac170f38f.